### PR TITLE
fix: absolute dir env vars + run passthrough/init installs in a subprocess

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ from meerschaum.plugins import add_plugin_argument, make_action, from_plugin_imp
 
 from .sync import sync
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 required = ['python-dotenv', 'envyaml']
 
 

--- a/subactions/default.py
+++ b/subactions/default.py
@@ -48,13 +48,17 @@ def _compose_default(
                 continue
             isolated_sysargs.append(arg)
 
-    ### Just launch a subprocess for the shell.
-    ### It's too much of a hassle otherwise.
-    _subprocess = compose_config.get('isolation', None) == 'subprocess'
+    ### Always run passthrough commands in a SUBPROCESS. In-process execution cannot
+    ### reliably redirect Meerschaum's import-time path resolution (notably the venvs
+    ### dir): re-pointing the root mid-process does not move where `install required` /
+    ### `setup plugins` write, so they land in the HOST's `~/.config/meerschaum/venvs`
+    ### instead of the project's `root/venvs` (the package installs, but the project
+    ### venvs stay empty). A fresh subprocess reads the compose env (absolute
+    ### MRSM_ROOT_DIR) at import, so paths/venvs resolve under the project root — this is
+    ### also how `compose init` already installs deps correctly.
+    _subprocess = True
     if action:
         info(f"Running '{' '.join(action)}' in compose project '{project_name}'...")
-    else:
-        _subprocess = True
 
     success, msg = run_mrsm_command(
         isolated_sysargs,

--- a/subactions/init.py
+++ b/subactions/init.py
@@ -119,9 +119,16 @@ def _compose_init(
     if existing_plugins:
         with replace_config(config):
             with replace_env(env):
+                ### Do NOT scope to `existing_plugins`: that list is discovered IN-PROCESS
+                ### (get_installed_plugins), where the already-imported paths/plugins module
+                ### doesn't pick up the compose MRSM_PLUGINS_DIR, so it only finds the
+                ### internal `compose` plugin — scoping the install to it skips every
+                ### project plugin (e.g. mqtt-connector → paho is never installed). Run
+                ### `install required` / `setup plugins` UNSCOPED so the subprocess (which
+                ### reads the absolute compose env at import) discovers all project plugins.
                 install_required_success, install_required_msg = (
                     run_mrsm_command(
-                        ['install', 'required'] + existing_plugins,
+                        ['install', 'required'],
                         compose_config,
                         capture_output=False,
                         debug=debug,
@@ -137,7 +144,7 @@ def _compose_init(
 
                 setup_success, setup_msg = (
                     run_mrsm_command(
-                        ['setup', 'plugins'] + existing_plugins,
+                        ['setup', 'plugins'],
                         compose_config,
                         capture_output=False,
                         debug=debug,

--- a/utils/config.py
+++ b/utils/config.py
@@ -352,6 +352,17 @@ def get_dir_paths(compose_config: Dict[str, Any], dir_name: str) -> List[pathlib
     return unique_paths
 
 
+def _resolve_abs(path_str: str, base_dir: pathlib.Path) -> str:
+    """
+    Resolve a (possibly relative) path string to an absolute POSIX path.
+    Relative values are resolved against `base_dir`, not the current CWD.
+    """
+    path = pathlib.Path(path_str)
+    if not path.is_absolute():
+        path = base_dir / path
+    return path.resolve().as_posix()
+
+
 def get_env_dict(compose_config: Dict[str, Any]) -> Dict[str, Any]:
     """
     Return a dictionary of environment variables.
@@ -399,6 +410,48 @@ def get_env_dict(compose_config: Dict[str, Any]) -> Dict[str, Any]:
 
     if compose_config.get('environment', None):
         env_dict.update(compose_config['environment'])
+
+    ### Ensure Meerschaum's directory env vars are ABSOLUTE paths.
+    ### `get_dir_paths()` already resolves `root_dir`/`plugins_dir` to absolute, but a
+    ### relative value in an `environment:` block (e.g. `MRSM_PLUGINS_DIR: "./plugins"`)
+    ### or in `.env` clobbers them via the `update()` above. A daemon or subprocess job
+    ### does NOT necessarily inherit the compose file's CWD (a Meerschaum daemon's
+    ### working directory is its root dir), so a relative plugins dir then resolves to
+    ### the wrong place and plugin imports fail with "No module named 'plugins.<name>'".
+    ### This applies to EVERY path-valued env var Meerschaum reads (root, config_dir,
+    ### plugins, venvs, work_dir) — drive the list off STATIC_CONFIG so it tracks
+    ### Meerschaum rather than a hardcoded pair. JSON (MRSM_CONFIG/MRSM_PATCH) and mode
+    ### vars (MRSM_RUNTIME) are intentionally excluded. Resolve relative values against
+    ### the compose file's directory (the same base `get_dir_paths()` uses).
+    from meerschaum.config.static import STATIC_CONFIG
+    env_keys = STATIC_CONFIG['environment']
+    dir_env_vars = [
+        env_keys[name]
+        for name in ('root', 'config_dir', 'plugins', 'venvs', 'work_dir')
+        if name in env_keys
+    ]
+    compose_file_path = compose_config.get('__file__', None)
+    base_dir = (
+        compose_file_path.parent
+        if isinstance(compose_file_path, pathlib.Path)
+        else pathlib.Path(os.getcwd())
+    )
+    for dir_key in dir_env_vars:
+        val = env_dict.get(dir_key, None)
+        if not val or not isinstance(val, str):
+            continue
+        ### `plugins` may be a JSON list of paths; the rest are single paths.
+        if val.lstrip().startswith('['):
+            try:
+                rel_paths = json.loads(val)
+            except Exception:
+                continue
+            env_dict[dir_key] = json.dumps(
+                [_resolve_abs(path_str, base_dir) for path_str in rel_paths],
+                separators=(',', ':'),
+            )
+        else:
+            env_dict[dir_key] = _resolve_abs(val, base_dir)
 
     none_keys = [key for key, val in env_dict.items() if val is None]
     for key in none_keys:


### PR DESCRIPTION
Robustness fixes for production jobs and dependency installs.

1. Absolute directory env vars (utils/config.py::get_env_dict) get_dir_paths() resolves root_dir/plugins_dir to absolute, but the subsequent `env_dict.update(compose_config['environment'])` let a relative value in an `environment:` block (e.g. `MRSM_PLUGINS_DIR: "./plugins"`) or `.env` clobber them. A Meerschaum daemon's CWD during plugin import is its root dir (not the compose-file dir), so a relative plugins dir resolved to the wrong place and every package plugin failed to import ("No module named 'plugins.sra'"). Jobs are always launched with `-d`, so `isolation: subprocess` did not avoid it. Now every path-valued env var Meerschaum reads (root, config_dir, plugins, venvs, work_dir — driven off STATIC_CONFIG['environment']) is re-resolved to an absolute path against the compose file's directory after the env merge.

2. Default passthrough runs in a subprocess (subactions/default.py) `mrsm compose install required` ran in-process (config isolation). Re-pointing the root mid-process does NOT move Meerschaum's import-time path resolution, so pip installed into the HOST venvs instead of the project's root/venvs (package installs, project venvs stay empty). Always run passthrough commands in a fresh subprocess, which reads the absolute compose env at import so venvs resolve under the project root. Deps install on demand, NOT on every `compose up`.

3. `compose init` installs unscoped (subactions/init.py) init scoped `install required`/`setup plugins` to a plugin list discovered IN-PROCESS, which only saw the internal `compose` plugin (same import-time path issue) — so project deps (e.g. paho for mqtt-connector) were never installed. Run them unscoped so the subprocess discovers all project plugins.